### PR TITLE
+ Added Support for PVC recovering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ resetpv
 ca.crt
 etcd.crt
 etcd.key
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Reset persistent volume status from terminating back to bound. [Here are the det
 
 ## Purpose
 
-When delete a kubernetes persistent volume by accident, it may stuck in the terminating status due to `kubernetes.io/pv-protection` finalizer prevent it from being deleted. You can use this tool to reset its status back to bound.
+When delete a kubernetes **persistent volume** by accident, it may stuck in the terminating status due to `kubernetes.io/pv-protection` finalizer prevent it from being deleted. You can use this tool to reset its status back to bound.
+
+Same thing applies when you delete a kubernetes **persistent volume claim** with auto-provisioning PV by accident, it may stuck in the terminating status due to `kubernetes.io/pv-protection` finalizer prevent it from being deleted. You can use this tool to reset its status back to bound.
 
 ## Installing
 
@@ -23,6 +25,7 @@ go build -o resetpv
 ```text
 Usage:
   resetpv [flags] <persistent volume name>
+  resetpv [flags] <persistent volume claim name incl. namespace>
 
 Flags:
       --etcd-ca        string   CA Certificate used by etcd (default "ca.crt")
@@ -32,6 +35,7 @@ Flags:
       --etcd-port      int      The etcd port number (default 2379)
       --k8s-key-prefix string   The etcd key prefix for kubernetes resources. (default "registry")
   -h, --help                    help for resetpv
+      --mode string             Mode = pv|pvc (default "pv")
 ```
 
 For simplicity, you can name the etcd certificate ca.crt, etcd.crt, etcd.key, and put them in the same directory as the tool(resetpv).
@@ -44,11 +48,18 @@ kubectl port-forward pods/etcd-member-master0 2379:2379 -n etcd
 
 `--k8s-key-prefix`: Default set to `registry` for the community version of kubernetes as it uses `/registry` as etcd key prefix, the key for persistent volume pv1 is `/registry/persistentvolumes/pv1`. Set to `kubernetes.io` for OpenShift as it uses `/kubernetes.io` as prefix and the key for pv1 is `/kubernetes.io/persistentvolumes/pv1`.
 
-Example:
+Example fo PV:
 
 ```shell
 ./resetpv --k8s-key-prefix kubernetes.io pv-eef4ec4b-326d-47e6-b11c-6474a5fd4d89
 ```
+
+Example fo PVC:
+
+```shell
+./resetpv --k8s-key-prefix registry --mode pvc default/testpvc
+```
+
 
 ## License
 

--- a/cmd/resetpv.go
+++ b/cmd/resetpv.go
@@ -198,7 +198,7 @@ func recoverPVC(ctx context.Context, client *clientv3.Client) error {
 
 	// Set PV status from Terminating to Bound by removing value of DeletionTimestamp and DeletionGracePeriodSeconds
 	if (*pvc).ObjectMeta.DeletionTimestamp == nil {
-		return fmt.Errorf("persistent volume claim [%s] is not in terminating status", pvName)
+		return fmt.Errorf("persistent volume claim [%s] is not in terminating status", pvcName)
 	}
 	(*pvc).ObjectMeta.DeletionTimestamp = nil
 	(*pvc).ObjectMeta.DeletionGracePeriodSeconds = nil

--- a/cmd/resetpv.go
+++ b/cmd/resetpv.go
@@ -187,7 +187,7 @@ func recoverPVC(ctx context.Context, client *clientv3.Client) error {
 	}
 
 	if len(resp.Kvs) < 1 {
-		return fmt.Errorf("cannot find persistent volume claim [%s] in etcd with key [%s]\nplease check the k8s-key-prefix and the persistent volume claim name are set correctly", pvName, key)
+		return fmt.Errorf("cannot find persistent volume claim [%s] in etcd with key [%s]\nplease check the k8s-key-prefix and the persistent volume claim name are set correctly", pvcName, key)
 	}
 
 	// Decode protobuf value to PV struct

--- a/cmd/resetpv.go
+++ b/cmd/resetpv.go
@@ -28,8 +28,10 @@ var (
 	etcdCA, etcdCert, etcdKey, etcdHost string
 	etcdPort                            int
 
+	mode         string
 	k8sKeyPrefix string
 	pvName       string
+	pvcName      string
 
 	cmd = &cobra.Command{
 		Use:   "resetpv [flags] <persistent volume name>",
@@ -39,18 +41,28 @@ var (
 			if len(args) != 1 {
 				return errors.New("requires one persistent volume name argument")
 			}
-			pvName = args[0]
+			if mode == "pv" {
+				pvName = args[0]
+			} else if mode == "pvc" {
+				pvcName = args[0]
+			} else {
+				return fmt.Errorf("mode '%s' is unkown, needs to be either 'pv' (default) or 'pvc'", mode)
+			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := resetPV()
-			return err
+			if mode == "pv" {
+				return resetPV()
+			} else {
+				return resetPVC()
+			}
 		},
 	}
 )
 
 // Execute reset the Terminating PersistentVolume to Bound status.
 func Execute() {
+	cmd.Flags().StringVar(&mode, "mode", "pv", "Mode = pv|pvc")
 	cmd.Flags().StringVar(&etcdCA, "etcd-ca", "ca.crt", "CA Certificate used by etcd")
 	cmd.Flags().StringVar(&etcdCert, "etcd-cert", "etcd.crt", "Public key used by etcd")
 	cmd.Flags().StringVar(&etcdKey, "etcd-key", "etcd.key", "Private key used by etcd")
@@ -74,6 +86,19 @@ func resetPV() error {
 	defer cancel()
 
 	return recoverPV(ctx, etcdCli)
+}
+
+func resetPVC() error {
+	etcdCli, err := etcdClient()
+	if err != nil {
+		return fmt.Errorf("cannot connect to etcd: %v", err)
+	}
+	defer etcdCli.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	return recoverPVC(ctx, etcdCli)
 }
 
 func etcdClient() (*clientv3.Client, error) {
@@ -142,5 +167,50 @@ func recoverPV(ctx context.Context, client *clientv3.Client) error {
 
 	// Write the updated protobuf value back to etcd
 	client.Put(ctx, key, fixedPV.String())
+	return nil
+}
+
+func recoverPVC(ctx context.Context, client *clientv3.Client) error {
+
+	gvk := schema.GroupVersionKind{Group: v1.GroupName, Version: "v1", Kind: "PersistentVolumeClaim"}
+	pvc := &v1.PersistentVolumeClaim{}
+
+	runtimeScheme := runtime.NewScheme()
+	runtimeScheme.AddKnownTypeWithName(gvk, pvc)
+	protoSerializer := protobuf.NewSerializer(runtimeScheme, runtimeScheme)
+
+	// Get PV value from etcd which in protobuf format
+	key := fmt.Sprintf("/%s/persistentvolumeclaims/%s", k8sKeyPrefix, pvcName)
+	resp, err := client.Get(ctx, key)
+	if err != nil {
+		return err
+	}
+
+	if len(resp.Kvs) < 1 {
+		return fmt.Errorf("cannot find persistent volume claim [%s] in etcd with key [%s]\nplease check the k8s-key-prefix and the persistent volume claim name are set correctly", pvName, key)
+	}
+
+	// Decode protobuf value to PV struct
+	_, _, err = protoSerializer.Decode(resp.Kvs[0].Value, &gvk, pvc)
+	if err != nil {
+		return err
+	}
+
+	// Set PV status from Terminating to Bound by removing value of DeletionTimestamp and DeletionGracePeriodSeconds
+	if (*pvc).ObjectMeta.DeletionTimestamp == nil {
+		return fmt.Errorf("persistent volume claim [%s] is not in terminating status", pvName)
+	}
+	(*pvc).ObjectMeta.DeletionTimestamp = nil
+	(*pvc).ObjectMeta.DeletionGracePeriodSeconds = nil
+
+	// Encode fixed PV struct to protobuf value
+	var fixedPVC bytes.Buffer
+	err = protoSerializer.Encode(pvc, &fixedPVC)
+	if err != nil {
+		return err
+	}
+
+	// Write the updated protobuf value back to etcd
+	client.Put(ctx, key, fixedPVC.String())
 	return nil
 }


### PR DESCRIPTION
I had the problem that i created a PVC with auto-provisioning of a PV for a deployment.
Then I accidentally deleted the PVC but the finalizer protected the PVC (and underlaying PV) from being deleted right away.

To use the new PVC Recover functionality one must supply the PVC Name (prefixed by the K8s namespace) and the flag ```--mode``` set to ```pvc```, e.g.

```resetpv --mode pvc --etcd-ca ca.crt --etcd-cert etcd.crt --etcd-key etcd.key default/testpvc```
